### PR TITLE
Add handling error with error first parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ Paribasan._toArray = (paribasan_object) => {
 
 Paribasan._checkIndexDir = () => {
   return new Promise((resolve, reject) => {
-    si.tellMeAboutMySearchIndex((info) => {
+    si.tellMeAboutMySearchIndex((err, info) => {
+      if (err) throw err;
+      
       if (info.totalDocs === 0) {
         console.log('Initialize indexing...')
         Paribasan.init().then(() => resolve(true))


### PR DESCRIPTION
when i use the search feature. i get error that info is 'null'. i think that the 'null' is for error parameter that must exist in first parameter. :D sory for bad english. What do you think?